### PR TITLE
Adjusted dependency requirement

### DIFF
--- a/debian/debian/control
+++ b/debian/debian/control
@@ -10,6 +10,6 @@ Homepage: http://mapcrafter.org
 
 Package: mapcrafter
 Architecture: any
-Depends: libpng, libjpeg-turbo8, libstdc++6
+Depends: libpng, libjpeg8, libstdc++6
 Description: High Performance Minecraft Map Renderer
  Mapcrafter is a high performance Minecraft map renderer written in C++.


### PR DESCRIPTION
was libjpeg should be either libjpeg8 or libjpeg-turbo8
Decided that libjpeg-turbo8 was possibly a better choice.
